### PR TITLE
Switch to a more performant locking library

### DIFF
--- a/EFCoreCache/EFCoreCache.csproj
+++ b/EFCoreCache/EFCoreCache.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="cx.BinarySerializer" Version="1.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.22" />
@@ -33,7 +34,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Memory.Data" Version="7.0.0" />

--- a/EFCoreCache/EFCoreCache.csproj
+++ b/EFCoreCache/EFCoreCache.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
     <PackageReference Include="cx.BinarySerializer" Version="1.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.22" />

--- a/EFCoreCache/EFCoreCache.csproj
+++ b/EFCoreCache/EFCoreCache.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.3" />
     <PackageReference Include="cx.BinarySerializer" Version="1.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.22" />

--- a/EFCoreCache/Interfaces/ILockProvider.cs
+++ b/EFCoreCache/Interfaces/ILockProvider.cs
@@ -1,13 +1,15 @@
-﻿namespace EFCoreCache.Interfaces;
-public interface ILockProvider
+﻿using AsyncKeyedLock;
+
+namespace EFCoreCache.Interfaces;
+public interface ILockProvider : IDisposable
 {
     /// <summary>
     ///     Tries to enter the sync lock
     /// </summary>
-    IDisposable Lock(CancellationToken cancellationToken = default);
+    AsyncNonKeyedLockReleaser Lock(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Tries to enter the async lock
     /// </summary>
-    Task<IDisposable> LockAsync(CancellationToken cancellationToken = default);
+    ValueTask<AsyncNonKeyedLockReleaser> LockAsync(CancellationToken cancellationToken = default);
 }

--- a/EFCoreCache/Providers/LockProvider.cs
+++ b/EFCoreCache/Providers/LockProvider.cs
@@ -1,20 +1,31 @@
-﻿using EFCoreCache.Interfaces;
-using NeoSmart.AsyncLock;
+﻿using AsyncKeyedLock;
+using EFCoreCache.Interfaces;
+using System.Runtime.CompilerServices;
 
 namespace EFCoreCache.Providers;
 
-public class LockProvider : ILockProvider
+public sealed class LockProvider : ILockProvider
 {
-    private readonly AsyncLock _lock = new();
+    private readonly AsyncNonKeyedLocker _lock = new();
 
     /// <summary>
     ///     Tries to enter the sync lock
     /// </summary>
-    public IDisposable Lock(CancellationToken cancellationToken = default) => _lock.Lock(cancellationToken);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public AsyncNonKeyedLockReleaser Lock(CancellationToken cancellationToken = default) => _lock.Lock(cancellationToken);
 
     /// <summary>
     ///     Tries to enter the async lock
     /// </summary>
-    public Task<IDisposable> LockAsync(CancellationToken cancellationToken = default) =>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<AsyncNonKeyedLockReleaser> LockAsync(CancellationToken cancellationToken = default) =>
         _lock.LockAsync(cancellationToken);
+
+    /// <summary>
+    ///     Disposes the lock
+    /// </summary>    
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
 }


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144